### PR TITLE
Update node sample to work with Sandbox credentials

### DIFF
--- a/connect-examples/v2/node_payment/README.rdoc
+++ b/connect-examples/v2/node_payment/README.rdoc
@@ -7,3 +7,5 @@ To get the app running:
 * npm install
 
 * npm start
+
+* open a browser and navigate to [localhost:3000](localhost:3000)

--- a/connect-examples/v2/node_payment/routes/index.js
+++ b/connect-examples/v2/node_payment/routes/index.js
@@ -12,7 +12,7 @@ var product_cost = {"001": 100, "002": 4900, "003": 500000}
 
 /* GET home page. */
 router.get('/', function(req, res, next) {
-  res.render('index', { title: 'Express Node.js Implementation', 'square_application_id': config.squareApplicationId });
+	res.render('index', { title: 'Express Node.js Implementation', 'square_application_id': config.squareApplicationId });
 });
 
 router.post('/charges/charge_card', function(req,res,next){
@@ -24,31 +24,41 @@ router.post('/charges/charge_card', function(req,res,next){
 		'Accept': 'application/json'
 	})
 	.end(function (response) {
-	  location = response.body.locations[0];
-	  
-	  var token = require('crypto').randomBytes(64).toString('hex');
-	  
-	  //Check if product exists
-	  if (!product_cost.hasOwnProperty(request_params.product_id)) {
-	  	return res.json({status: 400, errors: [{"detail": "Product Unavailable"}] })
-	  }
 
-	  //Make sure amount is a valid integer
-	  var amount = product_cost[request_params.product_id]
-	  
-	  request_body = {
-	  	card_nonce: request_params.nonce,
-	  	amount_money: {
-	  		amount: amount,
-	  		currency: 'USD'
-	  	},
-	  	idempotency_key: token
-	  }
-	  unirest.post(base_url + '/locations/' + location.id + "/transactions")
-	  .headers({
-		'Authorization': 'Bearer ' + config.squareAccessToken,
-		'Accept': 'application/json',
-		'Content-Type': 'application/json'
+		for (var i = response.body.locations.length - 1; i >= 0; i--) {
+			if(response.body.locations[i].capabilities.indexOf("CREDIT_CARD_PROCESSING")>-1){
+				location = response.body.locations[i];
+				break;
+			}
+			if(i==0){
+				return res.json({status: 400, errors: [{"detail": "No locations have credit card processing available."}] })
+			}
+		}
+		
+
+		var token = require('crypto').randomBytes(64).toString('hex');
+
+		//Check if product exists
+		if (!product_cost.hasOwnProperty(request_params.product_id)) {
+			return res.json({status: 400, errors: [{"detail": "Product Unavailable"}] })
+		}
+
+		//Make sure amount is a valid integer
+		var amount = product_cost[request_params.product_id]
+
+		request_body = {
+			card_nonce: request_params.nonce,
+			amount_money: {
+				amount: amount,
+				currency: 'USD'
+			},
+			idempotency_key: token
+		}
+		unirest.post(base_url + '/locations/' + location.id + "/transactions")
+		.headers({
+			'Authorization': 'Bearer ' + config.squareAccessToken,
+			'Accept': 'application/json',
+			'Content-Type': 'application/json'
 		})
 		.send(request_body)
 		.end(function(response){


### PR DESCRIPTION
Previously if you tried use the sample with just your sandbox credentials, you would get an error that the location was not enabled for card processing. This is because the sample would process the payment at the first location returned by the API, which for the sandbox environment doesn't have credit card processing enabled. 

Now the sample will process at the first location that has processing enabled, and throw an error if it can't find one. Additionally the instructions have been updated to tell you where point your browser to actually see the sample. 
