### PR TITLE
Correct API Call (TransactionsApi --> TransactionApi)

### DIFF
--- a/connect-examples/v2/php_checkout/templates/example-confirm-transaction.php
+++ b/connect-examples/v2/php_checkout/templates/example-confirm-transaction.php
@@ -12,7 +12,7 @@ $returnedTransactionId = $_GET["transactionId"] ;
 initApiClient() ;
 
 // Create a new API object to verify the transaction
-$transactionClient = new \SquareConnect\Api\TransactionsApi($GLOBALS['API_CLIENT']) ;
+$transactionClient = new \SquareConnect\Api\TransactionApi($GLOBALS['API_CLIENT']) ;
 
 // Ping the Transactions API endpoint for transaction details
 try {
@@ -25,7 +25,7 @@ try {
 
 } catch (Exception $e) {
   echo "The SquareConnect\Configuration object threw an exception while " .
-       "calling TransactionsApi->retrieveTransaction: ",
+       "calling TransactionApi->retrieveTransaction: ",
        $e->getMessage(), PHP_EOL ;
   exit ;
 }


### PR DESCRIPTION
Some of the API fixes from the original push are missing. The API reference is incorrect in both the error message and the actual call.