### PR TITLE
[PHP payment] Fixes how locations are filter for PHP < 5.5

### DIFF
--- a/connect-examples/v2/php_payment/process-card.php
+++ b/connect-examples/v2/php_payment/process-card.php
@@ -32,8 +32,9 @@ try {
   $locations = $locations_api->listLocations();
   #We look for a location that can process payments
   $location = current(array_filter($locations->getLocations(), function($location) {
-    return !empty($location->getCapabilities()) &&
-      in_array('CREDIT_CARD_PROCESSING', $location->getCapabilities());
+    $capabilities = $location->getCapabilities();
+    return is_array($capabilities) &&
+      in_array('CREDIT_CARD_PROCESSING', $capabilities);
   }));
 
 } catch (\SquareConnect\ApiException $e) {


### PR DESCRIPTION
`empty()` supports expressions since PHP 5.5. Before that, it only
supports variables[1]. Our example didn't work with PHP versions prior
5.5.

[1] http://ca2.php.net/empty