### PR TITLE
Fixed typo in function name example-checkout-curl.php

### DIFF
--- a/connect-examples/v2/php_checkout/templates/example-checkout-curl.php
+++ b/connect-examples/v2/php_checkout/templates/example-checkout-curl.php
@@ -26,7 +26,7 @@ if ($GLOBALS['STORE_NAME'] == null) {
 $orderArray = getOrderAsArray(/*Order ID or object from cart workflow */);
 
 // CURL HELPER FUNCTION: Get the location ID for the store
-$GLOBALS['LOCATION_ID'] = getMyLocationId($authzToken, $GLOBALS['STORE_NAME']);
+$GLOBALS['LOCATION_ID'] = getLocationId($authzToken, $GLOBALS['STORE_NAME']);
 if ($GLOBALS['LOCATION_ID'] == null) {
   echo "The location ID for '" . $GLOBALS['STORE_NAME'] . "' not found.";
   return;


### PR DESCRIPTION
Fixed typo/incorrect function name. Was looking for getMyLocationId() on example-curl-helpers.php and was confused I could not find it.