### PR TITLE
Remove escaping from !{results} -> #{results}

### DIFF
--- a/connect-examples/v2/node_payment/views/process-payment.pug
+++ b/connect-examples/v2/node_payment/views/process-payment.pug
@@ -1,4 +1,4 @@
 extends layout
 block content
   div
-    !{result}
+    #{result}


### PR DESCRIPTION
Removed the escaping from variable because of the following error:
```
/Users/federicoulfo/seethru/connect-api-examples/connect-examples/v2/node_payment/views/process-payment.pug:4:5
2| block content
3| div
> 4| !{result}
-----------^
5|

unexpected text "!{res"
```

Jade doc for escaping:
https://naltatis.github.io/jade-syntax-docs/#escaping