### PR TITLE
remove  form.recalculateSize() from template.

### DIFF
--- a/templates/web-ui/payment-form/basic/sqpaymentform-basic.js
+++ b/templates/web-ui/payment-form/basic/sqpaymentform-basic.js
@@ -8,7 +8,6 @@ var locationId = "REPLACE_ME";
 function buildForm(form) {
   if (SqPaymentForm.isSupportedBrowser()) {
     form.build();
-    form.recalculateSize();
   }
 }
 


### PR DESCRIPTION
The form.recalculateSize() should not be called before `paymentFormLoaded` callback.