### PR TITLE
Updated basic - digital wallet, custom, and digital-wallet-only templates

### DIFF
--- a/templates/web-ui/payment-form/basic-digital-wallet/sqpaymentform-basic.css
+++ b/templates/web-ui/payment-form/basic-digital-wallet/sqpaymentform-basic.css
@@ -138,7 +138,6 @@ fieldset {
   height: 48px;
   padding: 0;
   margin: 24px 0 24px;
-  background-image: url("https://masterpass.com/dyn/img/acc/global/mp_mark_hor_wht.svg");
   background-color: black;
   background-size: 100% 60%;
   background-repeat: no-repeat;

--- a/templates/web-ui/payment-form/basic-digital-wallet/sqpaymentform-basic.js
+++ b/templates/web-ui/payment-form/basic-digital-wallet/sqpaymentform-basic.js
@@ -102,6 +102,10 @@ var paymentForm = new SqPaymentForm({
       if (methods.masterpass === true) {
         walletBox.style.display = 'block';
         masterpassBtn.style.display = 'block';
+        masterpassBtn.style.backgroundImage = 'url('
+        + paymentForm.masterpassImageUrl()
+        + ')';
+
       }
       // Only show the button if Google Pay is enabled
       if (methods.googlePay === true) {

--- a/templates/web-ui/payment-form/custom/sq-payment-form.css
+++ b/templates/web-ui/payment-form/custom/sq-payment-form.css
@@ -154,7 +154,6 @@
 }
 .sq-masterpass {
   background-color: #000;
-  background-image: url(https://masterpass.com/dyn/img/btn/global/mp_chk_btn_384x048px.svg);
   background-repeat: no-repeat;
   background-size: contain;
   background-position: center right;

--- a/templates/web-ui/payment-form/custom/sq-payment-form.js
+++ b/templates/web-ui/payment-form/custom/sq-payment-form.js
@@ -91,6 +91,9 @@ var paymentForm = new SqPaymentForm({
       if (methods.masterpass === true) {
         var masterpassBtn = document.getElementById('sq-masterpass');
         masterpassBtn.style.display = 'inline-block';
+        masterpassBtn.style.backgroundImage = 'url('
+        + paymentForm.masterpassImageUrl()
+        + ')';
       }
     },
 

--- a/templates/web-ui/payment-form/digital-wallet-only/sqpaymentform-basic.css
+++ b/templates/web-ui/payment-form/digital-wallet-only/sqpaymentform-basic.css
@@ -74,7 +74,6 @@ fieldset {
   height: 48px;
   padding: 0;
   margin: 24px 0 24px;
-  background-image: url("https://masterpass.com/dyn/img/acc/global/mp_mark_hor_wht.svg");
   background-color: black;
   background-size: 100% 60%;
   background-repeat: no-repeat;

--- a/templates/web-ui/payment-form/digital-wallet-only/sqpaymentform-basic.js
+++ b/templates/web-ui/payment-form/digital-wallet-only/sqpaymentform-basic.js
@@ -72,6 +72,9 @@ var paymentForm = new SqPaymentForm({
       if (methods.masterpass === true) {
         walletBox.style.display = 'block';
         masterpassBtn.style.display = 'block';
+        masterpassBtn.style.backgroundImage = 'url('
+        + paymentForm.masterpassImageUrl()
+        + ')';
       }
       // Only show the button if Google Pay is enabled
       if (methods.googlePay === true) {


### PR DESCRIPTION
Three payment form template sets were updated to use the SqPaymentForm.masterpassImageUrl() function instead of the hard-coded masterpass background image url in the css class.