### PR TITLE
Moved require statement to top of file and uncommented

### DIFF
--- a/templates/php/sq_config.php
+++ b/templates/php/sq_config.php
@@ -7,6 +7,13 @@
  * use these templates at [docs.connect.squareup.com]
  */
 
+/**
+ * Include the Square Connect SDK loader
+ * Update the line below to reference the install path of the Connect SDK
+ */
+require_once 'local/path/to/autoload.php';
+
+
 // {{{ constants
 
 /**
@@ -114,10 +121,4 @@ function getLocationId() {
 
 // }}}
 
-/**
- * Include the Square Connect SDK loader
- * Uncomment the line below if you are installing the SDK manually instead of
- * using a package manager to install the Connect SDK
- */
-//require_once 'local/path/to/autoload.php';
 ?>


### PR DESCRIPTION
Per feedback, the `require` line is needed regardless of whether the Connect SDK is installed manually or with a package manager.