### PR TITLE
Added a define for an app secret for the sandbox environment

### DIFF
--- a/templates/php/sq_config.php
+++ b/templates/php/sq_config.php
@@ -35,6 +35,15 @@ if (!defined('_SQ_SANDBOX_APP_ID')) {
 }
 
 /**
+* Your Square SANDBOX environment application secret
+* REPLACE_ME = an application secret from the SANDBOX environment application
+* OAuth tab
+*/
+if (!defined('_SQ_SANDBOX_APP_SECRET')) {
+  define('_SQ_SANDBOX_APP_SECRET', "REPLACE_ME") ;
+}
+
+/**
 * Your Square application ID
 * REPLACE_ME = an application ID from the application Credentials tab
 */


### PR DESCRIPTION
Developer must be able to store their Square Sandbox environment application secret as a define if they want to test OAuth in the Sandbox environment.