### PR TITLE
Sjosey/fix checkout samples

### DIFF
--- a/connect-examples/v2/csharp_checkout/Pages/Checkout.cshtml.cs
+++ b/connect-examples/v2/csharp_checkout/Pages/Checkout.cshtml.cs
@@ -38,14 +38,14 @@ namespace csharp_checkout.Pages
         // create line items for the order
         // This example assumes the order information is retrieved and hard coded
         // You can find different ways to retrieve order information and fill in the following lineItems object.
-        List<CreateOrderRequestLineItem> lineItems = new List<CreateOrderRequestLineItem>();
+        List<OrderLineItem> lineItems = new List<OrderLineItem>();
 
         Money firstLineItemBasePriceMoney = new Money.Builder()
           .Amount(500L)
           .Currency("USD")
           .Build();
 
-        CreateOrderRequestLineItem firstLineItem = new CreateOrderRequestLineItem.Builder("1")
+        OrderLineItem firstLineItem = new OrderLineItem.Builder("1")
           .Name("Test Item A")
           .BasePriceMoney(firstLineItemBasePriceMoney)
           .Build();
@@ -57,22 +57,27 @@ namespace csharp_checkout.Pages
           .Currency("USD")
           .Build();
 
-        CreateOrderRequestLineItem secondLineItem = new CreateOrderRequestLineItem.Builder("3")
+        OrderLineItem secondLineItem = new OrderLineItem.Builder("3")
           .Name("Test Item B")
           .BasePriceMoney(secondLineItemBasePriceMoney)
           .Build();
 
         lineItems.Add(secondLineItem);
 
-        // create order with the line items
-        CreateOrderRequest order = new CreateOrderRequest.Builder()
+        // create Order object with line items
+        Order order = new Order.Builder(locationId)
           .LineItems(lineItems)
+          .Build();
+
+        // create order request with order
+        CreateOrderRequest orderRequest = new CreateOrderRequest.Builder()
+          .Order(order)
           .Build();
 
         // create checkout request with the previously created order
         CreateCheckoutRequest createCheckoutRequest = new CreateCheckoutRequest.Builder(
             Guid.NewGuid().ToString(),
-            order)
+            orderRequest)
           .Build();
 
         // create checkout response, and redirect to checkout page if successful

--- a/connect-examples/v2/csharp_checkout/csharp_checkout.csproj
+++ b/connect-examples/v2/csharp_checkout/csharp_checkout.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestSharp" Version="106.6.9" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Square" Version="4.0.0" />
+    <PackageReference Include="Square" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />

--- a/connect-examples/v2/php_checkout/checkout.php
+++ b/connect-examples/v2/php_checkout/checkout.php
@@ -30,22 +30,25 @@
       [
         "idempotency_key" => uniqid(),
         "order" => [
-          "line_items" => [
-          [
-            "name" => "Test Item A",
-            "quantity" => "1",
-            "base_price_money" => [
-              "amount" => 500,
-              "currency" => "USD"
-            ]
-          ],[
-            "name" => "Test Item B",
-            "quantity" => "3",
-            "base_price_money" => [
-              "amount" => 1000,
-              "currency" => "USD"
-            ]
-          ]]
+          "order" => [
+            "location_id" => $location_id,
+            "line_items" => [
+            [
+              "name" => "Test Item A",
+              "quantity" => "1",
+              "base_price_money" => [
+                "amount" => 500,
+                "currency" => "USD"
+              ]
+            ],[
+              "name" => "Test Item B",
+              "quantity" => "3",
+              "base_price_money" => [
+                "amount" => 1000,
+                "currency" => "USD"
+              ]
+            ]]
+          ]
         ]
       ]
     );

--- a/connect-examples/v2/php_checkout/composer.json
+++ b/connect-examples/v2/php_checkout/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "square/connect": "2.20190814.0",
+    "square/connect": "3.20200325.0",
     "vlucas/phpdotenv": "^3.3"
   }
 }


### PR DESCRIPTION
Updated checkout examples to use the embedded order object, since the CreateOrderRequest-level fields are now retired in the latest API version.