### PR TITLE
Was having trouble running test/template with Python 3.6.8 (x64), app…

### DIFF
--- a/connect-examples/v2/python_payment/README.md
+++ b/connect-examples/v2/python_payment/README.md
@@ -36,6 +36,10 @@ From the sample's root directory, run:
 
     python -m CGIHTTPServer
 
+Or with Python 3, run:
+   
+    python -m http.server --cgi
+
 You can then visit `localhost:8000/cgi-bin/index.py` in your browser to see the card form.
 
 If you're using your sandbox credentials, you can test a valid credit card

--- a/connect-examples/v2/python_payment/cgi-bin/index.py
+++ b/connect-examples/v2/python_payment/cgi-bin/index.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 # coding: utf-8
-import ConfigParser
+try:
+    import ConfigParser as cp
+except:
+    import configparser as cp
 
 # To read your secret credentials
-config = ConfigParser.ConfigParser()
-config.read('config.ini')
+config = cp.ConfigParser()
+try:
+    config.read(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'config.ini')))
+except:
+    config.read('config.ini')
 
 
 # Retrive credentials based on is_prod


### PR DESCRIPTION
Was having trouble running test/template with Python 3.6.8 (x64),  CGIHTTPServer is deprecated in Python 3.  Replaced with http.server module.  Also replaced ConfigParser in index.py with updated configparser. Put in catches to accomodate Python 2/existing function.  Annotated in readme.  Sample now runs with Python 3.6.8 on both localhost an web server.