### PR TITLE
updates v2/python_payment for strict python3

### DIFF
--- a/connect-examples/v2/python_payment/README.md
+++ b/connect-examples/v2/python_payment/README.md
@@ -34,14 +34,14 @@ for more information on the API sandbox.
 
 From the sample's root directory, run:
 
-    python -m CGIHTTPServer
+    python -m http.server --cgi
 
 You can then visit `localhost:8000/cgi-bin/index.py` in your browser to see the card form.
 
 If you're using your sandbox credentials, you can test a valid credit card
 transaction by providing the following card information in the form:
 
-* Card Number 4532 7597 3454 5858
+* Card Number 4111 1111 1111 1111
 * Card CVV 111
 * Card Expiration (Any time in the future)
 * Card Postal Code (Any valid US postal code)

--- a/connect-examples/v2/python_payment/cgi-bin/index.py
+++ b/connect-examples/v2/python_payment/cgi-bin/index.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # coding: utf-8
-import ConfigParser
+import configparser
 
 # To read your secret credentials
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read('config.ini')
 
 

--- a/connect-examples/v2/python_payment/cgi-bin/process_card.py
+++ b/connect-examples/v2/python_payment/cgi-bin/process_card.py
@@ -3,12 +3,12 @@
 from __future__ import print_function
 import uuid
 import cgi
-import ConfigParser
+import configparser
 
 from square.client import Client
 
 # To read your secret credentials
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read('config.ini')
 
 # Create instance of FieldStorage


### PR DESCRIPTION
I consulted with @hukid over Slack before making these changes. 

Summary:
* `-m CGIHTTPServer` → `-m http.server --cgi` in python3.
* casing of `ConfigParser` is all lower in python3.
* The example CC test fixture is out of date. 