### PR TITLE
remove unnecessary "location_id" in createOrder call.

### DIFF
--- a/connect-examples/v2/node_invoices/routes/invoice.js
+++ b/connect-examples/v2/node_invoices/routes/invoice.js
@@ -108,7 +108,6 @@ router.post("/create", async (req, res, next) => {
         }]
       },
       idempotencyKey, // Unique identifier for request
-      locationId,
     });
 
     // We set two important time below, scheduledAt and dueDate.


### PR DESCRIPTION
Remove the confusing useless extra location_id from the request body.