### PR TITLE
bump and lock mimemagic version

### DIFF
--- a/connect-examples/v2/rails_payment/Gemfile.lock
+++ b/connect-examples/v2/rails_payment/Gemfile.lock
@@ -87,7 +87,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.2)


### PR DESCRIPTION
The current locked version of mimemagic has been revoked, update the mimemagic version to the latest supported version to unblock `npm build`.