### PR TITLE
remove db:migrate command from README

### DIFF
--- a/connect-examples/v2/rails_payment/README.md
+++ b/connect-examples/v2/rails_payment/README.md
@@ -20,7 +20,6 @@ To get the app running:
 
 ```
 bundle install
-bundle exec rake db:create db:migrate # (No db in example, but keeps rails from complaining)
 ```
 
 * Update the .env file at the root with following values:


### PR DESCRIPTION
The `db:migrate` command isn't available because `rails/all` is commented out, removing it from the README