### PR TITLE
Add "Useful Links" section to each v2 example

### DIFF
--- a/connect-examples/v2/README.md
+++ b/connect-examples/v2/README.md
@@ -13,3 +13,6 @@ to take a custom payment.
 form.
 * __python_payment__: a simple Python server implementation with an accompanying payment
 form.
+
+
+**For more information, visit the Square SDK page: https://developer.squareup.com/docs/sdks**

--- a/connect-examples/v2/csharp_checkout/README.md
+++ b/connect-examples/v2/csharp_checkout/README.md
@@ -1,12 +1,14 @@
-﻿# Website Payment Processing Using the Square Checkout API: Csharp
+﻿# Useful Links
+
+* [C# (.NET) SDK Page](https://developer.squareup.com/docs/sdks/dotnet)
+* [Checkout API Overview](https://developer.squareup.com/docs/checkout-api/what-it-does)
+* [Checkout in the API Reference](https://developer.squareup.com/reference/square/checkout-api)
+
+# Website Payment Processing Using the Square Checkout API: Csharp
 
 This is a simple example application that utilizes Square's Checkout API 
 using ASP.NET Core Razor. This examples assumes you are familiar with C# development. 
 
-For more information about the Checkout API, see:
-* [What It Does](https://developer.squareup.com/docs/checkout-api/what-it-does)
-* [CreateCheckout - API Reference](https://developer.squareup.com/docs/api/connect/v2#endpoint-checkout-createcheckout)
-* [CreateCheckout - Connect C# SDK](https://github.com/square/connect-csharp-sdk/blob/master/docs/CheckoutApi.md) 
 
 There are two sections in this ReadMe.
 * [Setup](#setup) - Provides instructions for you to download and run the app.

--- a/connect-examples/v2/csharp_payment/README.md
+++ b/connect-examples/v2/csharp_payment/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [C# (.NET) SDK Page](https://developer.squareup.com/docs/sdks/dotnet)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Payments in the API Reference](https://developer.squareup.com/reference/square/payments-api)
+
 # Payment processing example: Csharp
 
 This sample demonstrates processing card payments with Square Connect API, using the

--- a/connect-examples/v2/java_payment/README.md
+++ b/connect-examples/v2/java_payment/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [Java SDK Page](https://developer.squareup.com/docs/sdks/java)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Payments in the API Reference](https://developer.squareup.com/reference/square/payments-api)
+
 # Java Payment Form Example
 
 This example hosts a payment form in Java. It is a Spring Boot app and requires Java 8 or newer. There are two sections in this ReadMe.

--- a/connect-examples/v2/node_invoices/README.md
+++ b/connect-examples/v2/node_invoices/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [Node.js SDK Page](https://developer.squareup.com/docs/sdks/nodejs)
+* [Invoices API Overview](https://developer.squareup.com/docs/invoices-api/overview)
+* [Invoices in the API Reference](https://developer.squareup.com/reference/square/invoices-api)
+
 # Invoice API Sample App
 
   - [Setup](#setup)

--- a/connect-examples/v2/node_orders-payments/README.md
+++ b/connect-examples/v2/node_orders-payments/README.md
@@ -1,3 +1,11 @@
+# Useful Links
+
+* [Node.js SDK Page](https://developer.squareup.com/docs/sdks/nodejs)
+* [Orders API - Order Ahead Overview](https://developer.squareup.com/docs/orders-api/order-ahead-usecase)
+* [Catalog API Overview](https://developer.squareup.com/docs/catalog-api/what-it-does)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Loyalty API Overview](https://developer.squareup.com/docs/loyalty-api/overview)
+
 # Order-Ahead Sample App
 
   - [Setup](#setup)

--- a/connect-examples/v2/node_payment/README.md
+++ b/connect-examples/v2/node_payment/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [Node.js SDK Page](https://developer.squareup.com/docs/sdks/nodejs)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Payments in the API Reference](https://developer.squareup.com/reference/square/payments-api)
+
 # Payment processing example: Node JS
 
 There are two sections in this ReadMe.

--- a/connect-examples/v2/node_subscription/README.md
+++ b/connect-examples/v2/node_subscription/README.md
@@ -1,3 +1,10 @@
+# Useful Links
+
+* [Node.js SDK Page](https://developer.squareup.com/docs/sdks/nodejs)
+* [Subscriptions API Overview](https://developer.squareup.com/docs/subscriptions/overview)
+* [Catalog API Overview](https://developer.squareup.com/docs/catalog-api/what-it-does)
+* [Customers API Overview](https://developer.squareup.com/docs/customers-groups-segments/what-they-are)
+
 # Subscriptions API Sample App
 
   - [Overview](#overview)

--- a/connect-examples/v2/php_checkout/README.md
+++ b/connect-examples/v2/php_checkout/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [PHP SDK Page](https://developer.squareup.com/docs/sdks/php)
+* [Checkout API Overview](https://developer.squareup.com/docs/checkout-api/what-it-does)
+* [Checkout in the API Reference](https://developer.squareup.com/reference/square/checkout-api)
+
 Square Checkout Demo
 =========================
 

--- a/connect-examples/v2/php_payment/README.md
+++ b/connect-examples/v2/php_payment/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [PHP SDK Page](https://developer.squareup.com/docs/sdks/php)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Payments in the API Reference](https://developer.squareup.com/reference/square/payments-api)
+
 # Payment processing example: PHP
 
 This sample demonstrates processing card payments with Square Connect API, using the

--- a/connect-examples/v2/python_payment/README.md
+++ b/connect-examples/v2/python_payment/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [Python SDK Page](https://developer.squareup.com/docs/sdks/python)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Payments in the API Reference](https://developer.squareup.com/reference/square/payments-api)
+
 # Payment processing example: Python
 
 This sample demonstrates processing card payments with Square Connect API, using the

--- a/connect-examples/v2/rails_payment/README.md
+++ b/connect-examples/v2/rails_payment/README.md
@@ -1,3 +1,9 @@
+# Useful Links
+
+* [Ruby SDK Page](https://developer.squareup.com/docs/sdks/ruby)
+* [Payments API Overview](https://developer.squareup.com/docs/payments)
+* [Payments in the API Reference](https://developer.squareup.com/reference/square/payments-api)
+
 # Payment processing example: Ruby On Rails
 
 


### PR DESCRIPTION
In order to create a bidirectional link between the apps and the SDK reference, we added a section for useful links at the beginning of each sample app, linking back to appropriate places in the documentation, based on both the development language and the APIs used in that particular sample app.