### PR TITLE
Fix hardcoded currency in seed script for node_orders_payments sample app

### DIFF
--- a/connect-examples/v2/node_orders-payments/bin/script/sample-seed-data.json
+++ b/connect-examples/v2/node_orders-payments/bin/script/sample-seed-data.json
@@ -60,7 +60,7 @@
             "pricingType": "FIXED_PRICING",
             "priceMoney": {
               "amount": 995,
-              "currency": "USD"
+              "currency": "CURRENCY"
             }
           }
         }],
@@ -95,7 +95,7 @@
             "pricingType": "FIXED_PRICING",
             "priceMoney": {
               "amount": 675,
-              "currency": "USD"
+              "currency": "CURRENCY"
             }
           }
         }],
@@ -131,7 +131,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 495,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -168,7 +168,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 1195,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -204,7 +204,7 @@
             "pricingType": "FIXED_PRICING",
             "priceMoney": {
               "amount": 895,
-              "currency": "USD"
+              "currency": "CURRENCY"
             }
           }
         }],
@@ -240,7 +240,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 695,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -276,7 +276,7 @@
             "pricingType": "FIXED_PRICING",
             "priceMoney": {
               "amount": 495,
-              "currency": "USD"
+              "currency": "CURRENCY"
             }
           }
         }],
@@ -312,7 +312,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 495,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -349,7 +349,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 995,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -386,7 +386,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 1495,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -423,7 +423,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 695,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }
@@ -459,7 +459,7 @@
               "pricingType": "FIXED_PRICING",
               "priceMoney": {
                 "amount": 695,
-                "currency": "USD"
+                "currency": "CURRENCY"
               }
             }
           }


### PR DESCRIPTION
The seed script (which automatically creates catalog objects for the user before running the app), is using a data file which has `USD` hardcoded as the currency. This means that non-US users will not be able to run the seed script at all. I changed the seed script to use `main` as the locationID, and retrieve the actual currency from that. This requires no changes to documentation or .env file. 