### PR TITLE
Standardize java_catalog sample app README

### DIFF
--- a/connect-examples/v2/java_catalog/README.md
+++ b/connect-examples/v2/java_catalog/README.md
@@ -1,4 +1,10 @@
-# Catalog API Demo App
+# Useful Links
+
+- [Square Java SDK](https://developer.squareup.com/docs/sdks/java)
+- [Catalog API Overview](https://developer.squareup.com/docs/catalog-api/what-it-does)
+- [Catalog in the API Reference](https://developer.squareup.com/reference/square/catalog-api)
+
+# Catalog API Sample App
 
 This is a sample command line application providing examples of common Catalog API interactions.
 


### PR DESCRIPTION
Add `Useful Links` section to the migrated app.