### PR TITLE
Update gift card sample to use Cards API

### DIFF
--- a/connect-examples/v2/node_gift-cards/routes/seed.js
+++ b/connect-examples/v2/node_gift-cards/routes/seed.js
@@ -20,7 +20,8 @@ const { v4: uuidv4 } = require("uuid");
 const {
   customersApi,
   giftCardsApi,
-  giftCardActivitiesApi
+  giftCardActivitiesApi,
+  cardsApi
 } = require("../util/square-client");
 
 const locationId = process.env[`SQUARE_LOCATION_ID`];
@@ -40,8 +41,9 @@ router.post("/:customerId/create-card", checkLoginStatus, checkCustomerIdMatch, 
   try {
     const customerId = req.params.customerId;
     const gan = req.query.gan;
-    const cardNonce = "cnon:card-nonce-ok"
-    await customersApi.createCustomerCard(customerId, { cardNonce });
+
+    const createCardRequest = generateCreateCardRequest(customerId);
+    await cardsApi.createCard(createCardRequest);
 
     // Redirect to the add-funds page, which will now present the newly created card.
     res.redirect("/gift-card/" + gan + "/add-funds/?cardCreated=success");
@@ -212,6 +214,19 @@ function generateGiftCardDecativationRequest(gan) {
         // In the future we will support other reasons.
         reason: "SUSPICIOUS_ACTIVITY"
       }
+    }
+  }
+}
+
+/**
+ * Helper function to build a `create card` API request payload to create a test card on file.
+ */
+function generateCreateCardRequest(customerId) {
+  return {
+    idempotencyKey: uuidv4(),
+    sourceId: "cnon:card-nonce-ok",
+    card: {
+      customerId
     }
   }
 }

--- a/connect-examples/v2/node_gift-cards/util/square-client.js
+++ b/connect-examples/v2/node_gift-cards/util/square-client.js
@@ -34,7 +34,8 @@ const {
   customersApi,
   ordersApi,
   paymentsApi,
-  locationsApi
+  locationsApi,
+  cardsApi
 } = new Client(config);
 
 module.exports = {
@@ -43,5 +44,6 @@ module.exports = {
   customersApi,
   ordersApi,
   paymentsApi,
-  locationsApi
+  locationsApi,
+  cardsApi
 };


### PR DESCRIPTION
Since the `CreateCustomerCard` endpoint is now deprecated, the replacement is using the Cards API which is currently in Beta. This PR changes all usages of `createCustomerCard` and the deprecated card object (as part of the Customers API) to `createCard` and `listCards` as part of the [Cards API](https://developer.squareup.com/reference/square/cards/).