### PR TITLE
Fix maximum gift card balance issue

### DIFF
--- a/connect-examples/v2/node_gift-cards/public/js/amount-bar.js
+++ b/connect-examples/v2/node_gift-cards/public/js/amount-bar.js
@@ -127,5 +127,12 @@ class AmountBar {
     } else {
       this.setAmountChosen(buttons[0].getAttribute("amount-bar-value"));
     }
+
+    // Set the text for the `pay button` in the case where the maximum balance has been reached.
+    // Disable the custom amount text field as well.
+    if (this.maxAllowedToAdd === 0) {
+      document.getElementById("pay-button").innerHTML = "Maximum gift card balance reached";
+      document.getElementById("custom-amount-text").disabled = true;
+    }
   }
 }

--- a/connect-examples/v2/node_gift-cards/public/js/pretty-select-dropdown.js
+++ b/connect-examples/v2/node_gift-cards/public/js/pretty-select-dropdown.js
@@ -1,4 +1,3 @@
-
 class PrettySelectDropdown {
   /**
    * Class for handling the drop down selection elements
@@ -26,7 +25,6 @@ class PrettySelectDropdown {
    *    addonIds: ["createCustomer"],     // additional elements added to the dropdown select list
    *    placeholder:  "Select customer"   // placeholder text to display
    *    placeholderImg: "/placeholder.svg"  // placeholder for img
-   *    disableSubmissionByDefault: true  // Whether the submission button should be disabled by default
    * }
    */
 
@@ -245,27 +243,44 @@ class PrettySelectDropdown {
   /**
    * configure the input listener for #pretty-dropdown__value and disable the
    * submit button if the value of #pretty-dropdown__value is empty.
-   * If the `disableSubmissionByDefault` option is present, its value will determine
-   * whether the submission button is disabled or not.
    */
   _configureElements() {
-    var valueInput = document.getElementById("pretty-dropdown__value");
-    var submitButton = valueInput.closest("form").querySelector(":scope > button[type=submit]");
-    var self = this;
+    this.valueInput = document.getElementById("pretty-dropdown__value");
+    this.submitButton = this.valueInput.closest("form").querySelector(":scope > button[type=submit]");
+    this.addInputEventListener();
+  }
 
-    valueInput.addEventListener('input', function () {
-      if (valueInput.value !== "") {
-        if(!self.options.disableSubmissionByDefault) {
-          // If this option is not present or set to false, the button should be enabled.
-          // Otherwise, we keep it disabled.
-          submitButton.disabled = false;
-        }
-      } else {
-        submitButton.disabled = true;
-      }
-    });
+  /**
+   * Removes the input event listener specified by the `handler` function.
+   */
+  removeInputEventListener() {
+    this.valueInput.removeEventListener("input", this.handler.bind(this));
+  }
 
+  /**
+   * Adds the input event listener to the dropdown, and runs the code specified in `handler` function.
+   * If the disable parameter is set to true, the button for submission will always be disabled.
+   *
+   * @param {*} disable - a flag for whether or not the button should be disabled.
+   */
+  addInputEventListener(disable = false) {
+    this.disableOverride = disable;
+    this.valueInput.addEventListener("input", this.handler.bind(this));
     var inputEvent = new Event("input");
-    valueInput.dispatchEvent(inputEvent);
+    this.valueInput.dispatchEvent(inputEvent);
+  }
+
+  /**
+   * The input event handler function to change the state of the submit button.
+   */
+  handler() {
+    if (this.valueInput.value !== "") {
+      // Check if there is an override to always disable the button. If that's the case, don't enable.
+      if(!this.disableOverride) {
+        this.submitButton.disabled = false;
+      }
+    } else {
+      this.submitButton.disabled = true;
+    }
   }
 }

--- a/connect-examples/v2/node_gift-cards/public/js/pretty-select-dropdown.js
+++ b/connect-examples/v2/node_gift-cards/public/js/pretty-select-dropdown.js
@@ -26,6 +26,7 @@ class PrettySelectDropdown {
    *    addonIds: ["createCustomer"],     // additional elements added to the dropdown select list
    *    placeholder:  "Select customer"   // placeholder text to display
    *    placeholderImg: "/placeholder.svg"  // placeholder for img
+   *    disableSubmissionByDefault: true  // Whether the submission button should be disabled by default
    * }
    */
 
@@ -243,15 +244,22 @@ class PrettySelectDropdown {
 
   /**
    * configure the input listener for #pretty-dropdown__value and disable the
-   * submit button if the value of #pretty-dropdown__value is empty
+   * submit button if the value of #pretty-dropdown__value is empty.
+   * If the `disableSubmissionByDefault` option is present, its value will determine
+   * whether the submission button is disabled or not.
    */
   _configureElements() {
     var valueInput = document.getElementById("pretty-dropdown__value");
     var submitButton = valueInput.closest("form").querySelector(":scope > button[type=submit]");
+    var self = this;
 
     valueInput.addEventListener('input', function () {
       if (valueInput.value !== "") {
-        submitButton.disabled = false;
+        if(!self.options.disableSubmissionByDefault) {
+          // If this option is not present or set to false, the button should be enabled.
+          // Otherwise, we keep it disabled.
+          submitButton.disabled = false;
+        }
       } else {
         submitButton.disabled = true;
       }

--- a/connect-examples/v2/node_gift-cards/views/pages/add-funds.ejs
+++ b/connect-examples/v2/node_gift-cards/views/pages/add-funds.ejs
@@ -112,7 +112,7 @@
       <script>
         new PrettySelectDropdown("cards-on-file-dropdown", 
         <%- stringifyJSON(cardsData) %>, 
-        {placeholder: "Select card", placeholderImg: "/images/no-card.svg"});
+        {placeholder: "Select card", placeholderImg: "/images/no-card.svg", disableSubmissionByDefault: <%= (maxLimit - Number(giftCard.balanceMoney.amount)) === 0 %>});
       </script>
       <% } else { %>
         <script>

--- a/connect-examples/v2/node_gift-cards/views/pages/add-funds.ejs
+++ b/connect-examples/v2/node_gift-cards/views/pages/add-funds.ejs
@@ -115,11 +115,11 @@
         {placeholder: "Select card", placeholderImg: "/images/no-card.svg"});
       </script>
       <% } else { %>
-        <script>
-          new PrettySelectDropdown("cards-on-file-dropdown",
+      <script>
+        const dropdown = new PrettySelectDropdown("cards-on-file-dropdown",
           <%- stringifyJSON(cardsData) %>,
           {placeholder: "Select card", placeholderImg: "/images/no-card.svg", addonIds:["no-card"]});
-        </script>
+      </script>
       <% } %>
 
       <script>

--- a/connect-examples/v2/node_gift-cards/views/pages/add-funds.ejs
+++ b/connect-examples/v2/node_gift-cards/views/pages/add-funds.ejs
@@ -110,9 +110,9 @@
 
       <% if (cards.length > 0) { %>
       <script>
-        new PrettySelectDropdown("cards-on-file-dropdown", 
+        const dropdown = new PrettySelectDropdown("cards-on-file-dropdown",
         <%- stringifyJSON(cardsData) %>, 
-        {placeholder: "Select card", placeholderImg: "/images/no-card.svg", disableSubmissionByDefault: <%= (maxLimit - Number(giftCard.balanceMoney.amount)) === 0 %>});
+        {placeholder: "Select card", placeholderImg: "/images/no-card.svg"});
       </script>
       <% } else { %>
         <script>
@@ -123,7 +123,7 @@
       <% } %>
 
       <script>
-        const amountBar = new AmountBar("amount-bar", <%- formatMoney %>, "<%= currency %>", <%= maxLimit - Number(giftCard.balanceMoney.amount) %>);
+        const amountBar = new AmountBar("amount-bar", <%- formatMoney %>, "<%= currency %>", <%= maxLimit - Number(giftCard.balanceMoney.amount) %>, dropdown);
       </script>
   </body>
 


### PR DESCRIPTION
When the gift card is loaded to its maximum value, we still allow the `pay button` to be pressed. This PR addresses this issue by disabling the `pay button` in the case of a gift card reaching its maximum allowed balance according to the Gift Card API.