### PR TITLE
Restrict PHP version to < 8.1

### DIFF
--- a/connect-examples/oauth/php/README.md
+++ b/connect-examples/oauth/php/README.md
@@ -22,7 +22,7 @@ After you've downloaded Composer, install the dependencies with the following
 command from this directory:
 
 ```
-php composer.phar install
+composer install
 ```
 
 ### Step 2: Get your credentials and set the redirect URL:

--- a/connect-examples/oauth/php/README.md
+++ b/connect-examples/oauth/php/README.md
@@ -10,6 +10,10 @@ along with the comments included in `sandbox_callback.php`.
 
 ## Getting started
 
+### Requirements
+
+* 7.1 <= PHP < 8.1
+
 ### Step 1: Download Composer and dependencies
 
 This application requires the PHP Square SDK as well as DotEnv for reading environment variables, which you install via

--- a/connect-examples/oauth/php/composer.json
+++ b/connect-examples/oauth/php/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "square/square": "17.1.0.20220120",
-    "vlucas/phpdotenv": "^3.3"
+    "vlucas/phpdotenv": "^3.3",
+    "php": "<8.1"
   }
 }

--- a/connect-examples/oauth/php/request_token.php
+++ b/connect-examples/oauth/php/request_token.php
@@ -15,6 +15,12 @@ use Dotenv\Dotenv;
 $dotenv = Dotenv::create(__DIR__);
 $dotenv->load();
 
+// Make sure the sample app only runs with PHP < 8.1 for now.
+if (version_compare(phpversion(), '8.1.0', '>=')) {
+  displayError("Unsupported PHP version",
+    "This sample app is meant to be run with PHP version < 8.1. Change your PHP version and try again.");
+}
+
 // Specify the permissions and url encode the spaced separated list.
 $permissions = urlencode(
                   "ITEMS_READ " . 

--- a/connect-examples/v2/node_orders-payments/routes/checkout.js
+++ b/connect-examples/v2/node_orders-payments/routes/checkout.js
@@ -324,7 +324,7 @@ router.post("/add-delivery-details", async (req, res, next) => {
             },
             expectedShippedAt: deliveryTime,
           },
-        },],
+        }, ],
         // Add an arbitratry $2.00 taxable delivery fee to the order
         serviceCharges: [{
           // replace serviceCharges if the order is updated again, otherwise add a new serviceCharge.
@@ -357,9 +357,10 @@ router.post("/add-delivery-details", async (req, res, next) => {
  * Description:
  *  Render the page for customer to submit payment information (a nounce) in order to pay the order
  *
- *  We will render SqPaymentForm in this step, it takes credit card informaiton on the client, convert them into
- *  a nonce through square service securely. You can learn more about the SqPaymentForm here:
- *  https://developer.squareup.com/docs/payment-form/overview
+ *  We will render the payment page using the Web Payment SDK in this step.
+ *  It takes credit card information on the client, and converts them into
+ *  a nonce through square service securely. You can learn more about the Web Payment SDK here:
+ *  https://developer.squareup.com/docs/web-payments/overview
  *
  * Query Parameters:
  *  orderId: Id of the order to be updated
@@ -441,7 +442,7 @@ router.post("/payment", async (req, res, next) => {
           amountMoney: order.totalMoney, // Provides total amount of money and currency to charge for the order.
           orderId: order.id, // Order that is associated with the payment
         });
-    
+
         const result = JSON.stringify(payment, (key, value) => {
           return typeof value === "bigint" ? parseInt(value) : value;
         }, 4);
@@ -451,7 +452,7 @@ router.post("/payment", async (req, res, next) => {
         res.json(error.result);
       }
     } else {
-      try{
+      try {
         // Settle an order with a total of 0.
         const { result: { payment } } = await ordersApi.payOrder(orderId, {
           idempotencyKey

--- a/connect-examples/v2/php_checkout/README.md
+++ b/connect-examples/v2/php_checkout/README.md
@@ -15,7 +15,7 @@ It takes a single payment, declared by the user, and creates an order to use in 
 
 ### Requirements
 
-* PHP >= 7.1
+* 7.1 <= PHP < 8.1
 
 ### Install the PHP client library
 
@@ -28,14 +28,14 @@ file. To install the client library:
 2. Run the following command from the directory containing `composer.json`:
 
 ```
-php composer.phar install
+composer install
 ```
 
 ### Specify your application credentials
 
-In order for the example to work, you must edit the file called `.env` with your application credentials and environment configuration.
+In order for the example to work, you must create a new file `.env` by copying the contents of the `.env.example` file. Edit this file with your application credentials and environment configuration.
 
-Open your [application dashboard](https://developer.squareup.com/). Now supply either production, sandbox, or both credentials. Open this file and update the following variables:
+Open your [developer dashboard](https://developer.squareup.com/). Now supply either production, sandbox, or both credentials. Open this file and update the following variables:
 * WARNING: never upload .env with your credential/access_token
 
 | Variable               |  Type    |   Description   |

--- a/connect-examples/v2/php_checkout/checkout.php
+++ b/connect-examples/v2/php_checkout/checkout.php
@@ -1,5 +1,12 @@
 <?php
 
+// Make sure the sample app only runs with PHP < 8.1 for now.
+if (version_compare(phpversion(), '8.1.0', '>=')) {
+  echo 'Unsupported PHP version<br/>';
+  echo '<strong>This sample app is meant to be run with PHP version < 8.1. Change your PHP version and try again.</strong><br/>';
+  exit();
+}
+
 // Note this line needs to change if you don't use Composer:
 // require('square-php-sdk/autoload.php');
 require 'vendor/autoload.php';

--- a/connect-examples/v2/php_checkout/composer.json
+++ b/connect-examples/v2/php_checkout/composer.json
@@ -1,6 +1,7 @@
 {
   "require": {
     "square/square": "*",
-    "vlucas/phpdotenv": "^3.3"
+    "vlucas/phpdotenv": "^3.3",
+    "php": "<8.1"
   }
 }

--- a/connect-examples/v2/php_payment/README.md
+++ b/connect-examples/v2/php_payment/README.md
@@ -16,7 +16,7 @@ There are two sections in this README.
 
 ### Requirements
 
-* PHP >= 7.1
+* 7.1 <= PHP < 8.1
 
 ### Install the PHP client library
 
@@ -29,16 +29,16 @@ file. To install the client library:
 2. Run the following command from the directory containing `composer.json`:
 
     ```
-    php composer.phar install
+    composer install
     ```
 
 ### Specify your application credentials
 
-Create a file named `.env` in the root directory of this example. `.env.example` is an example of what the `.env` file should look like. Fill in values for `SQUARE_APPLICATION_ID`, `SQUARE_ACCESS_TOKEN`, and `SQUARE_LOCATION_ID` with your sandbox or production credentials.
+In order for the example to work, you must create a new file `.env` by copying the contents of the `.env.example` file. Edit this file with your application credentials and environment configuration.
    <b>WARNING</b>: never save your credentials in your code.
 
 
-Open your [application dashboard](https://developer.squareup.com/apps). Now supply either production, sandbox, or both credentials. Open this file and update the following variables:
+Open your [developer dashboard](https://developer.squareup.com/apps). Now supply either production, sandbox, or both credentials. Open this file and update the following variables:
 * WARNING: never upload .env with your credential/access_token
 
 | Variable               |  Type    |   Description   |
@@ -53,9 +53,9 @@ Open your [application dashboard](https://developer.squareup.com/apps). Now supp
 
 From the sample's root directory, run:
 
-    php -S localhost:8000
+    php -S localhost:8888
 
-You can then visit [`localhost:8000`](http://localhost:8000) in your browser to see the payment form.
+You can then visit [`localhost:8888`](http://localhost:8888) in your browser to see the payment form.
 
 If you're using your sandbox credentials, you can test a valid credit card
 payment by providing the following card information in the form:

--- a/connect-examples/v2/php_payment/composer.json
+++ b/connect-examples/v2/php_payment/composer.json
@@ -2,6 +2,7 @@
   "require": {
     "square/square": "*",
     "vlucas/phpdotenv": "^3.3",
-    "ramsey/uuid": "*"
+    "ramsey/uuid": "*",
+    "php": "<8.1"
   }
 }

--- a/connect-examples/v2/php_payment/utils/location-info.php
+++ b/connect-examples/v2/php_payment/utils/location-info.php
@@ -1,5 +1,12 @@
 <?php
 
+// Make sure the sample app only runs with PHP < 8.1 for now.
+if (version_compare(phpversion(), '8.1.0', '>=')) {
+  echo 'Unsupported PHP version<br/>';
+  echo '<strong>This sample app is meant to be run with PHP version < 8.1. Change your PHP version and try again.</strong><br/>';
+  exit();
+}
+
 // Note this line needs to change if you don't use Composer:
 // require('square-php-sdk/autoload.php');
 require 'vendor/autoload.php';


### PR DESCRIPTION
Since we have some warning messages for the SDK when using php version >= 8.1, we want to restrict the sample apps to using old versions. This should be fixed around end of Feb.

This PR:
1. Restricts PHP version in the composer.json file.
2. Restricts PHP version in code.
3. Adds information to the README and removes some incosistencies.
4. Remove some references to sqpaymentform I've noticed.