### PR TITLE
chore: upgrade Spring Boot to 2.6.6 in the Java payments example

### DIFF
--- a/connect-examples/v2/java_payment/pom.xml
+++ b/connect-examples/v2/java_payment/pom.xml
@@ -9,17 +9,17 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.0.4.RELEASE</version>
+    <version>2.6.6</version>
   </parent>
 
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <webjars-bootstrap.version>4.1.3</webjars-bootstrap.version>
-    <webjars-jquery-ui.version>1.12.1</webjars-jquery-ui.version>
-    <webjars-jquery.version>3.3.1</webjars-jquery.version>
-    <thymeleaf.version>3.0.9.RELEASE</thymeleaf.version>
+    <webjars-bootstrap.version>5.1.3</webjars-bootstrap.version>
+    <webjars-jquery-ui.version>1.13.1</webjars-jquery-ui.version>
+    <webjars-jquery.version>3.6.0</webjars-jquery.version>
+    <thymeleaf-spring5.version>3.0.9.RELEASE</thymeleaf-spring5.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This updates Spring Boot to the latest version 2.6.6 in order to avoid a potential vulnerability (CVE-2022-22965).