### PR TITLE
Allow PHP version >= 8.1 on sample apps

### DIFF
--- a/connect-examples/oauth/php/README.md
+++ b/connect-examples/oauth/php/README.md
@@ -12,7 +12,7 @@ along with the comments included in `sandbox_callback.php`.
 
 ### Requirements
 
-* 7.1 <= PHP < 8.1
+* 7.1 <= PHP
 
 ### Step 1: Download Composer and dependencies
 

--- a/connect-examples/oauth/php/composer.json
+++ b/connect-examples/oauth/php/composer.json
@@ -1,7 +1,6 @@
 {
   "require": {
-    "square/square": "17.1.0.20220120",
-    "vlucas/phpdotenv": "^3.3",
-    "php": "<8.1"
+    "square/square": "18.0.0.20220420",
+    "vlucas/phpdotenv": "^3.3"
   }
 }

--- a/connect-examples/oauth/php/request_token.php
+++ b/connect-examples/oauth/php/request_token.php
@@ -15,12 +15,6 @@ use Dotenv\Dotenv;
 $dotenv = Dotenv::create(__DIR__);
 $dotenv->load();
 
-// Make sure the sample app only runs with PHP < 8.1 for now.
-if (version_compare(phpversion(), '8.1.0', '>=')) {
-  displayError("Unsupported PHP version",
-    "This sample app is meant to be run with PHP version < 8.1. Change your PHP version and try again.");
-}
-
 // Specify the permissions and url encode the spaced separated list.
 $permissions = urlencode(
                   "ITEMS_READ " . 

--- a/connect-examples/v2/php_checkout/README.md
+++ b/connect-examples/v2/php_checkout/README.md
@@ -15,7 +15,7 @@ It takes a single payment, declared by the user, and creates an order to use in 
 
 ### Requirements
 
-* 7.1 <= PHP < 8.1
+* 7.1 <= PHP
 
 ### Install the PHP client library
 

--- a/connect-examples/v2/php_checkout/checkout.php
+++ b/connect-examples/v2/php_checkout/checkout.php
@@ -1,12 +1,5 @@
 <?php
 
-// Make sure the sample app only runs with PHP < 8.1 for now.
-if (version_compare(phpversion(), '8.1.0', '>=')) {
-  echo 'Unsupported PHP version<br/>';
-  echo '<strong>This sample app is meant to be run with PHP version < 8.1. Change your PHP version and try again.</strong><br/>';
-  exit();
-}
-
 // Note this line needs to change if you don't use Composer:
 // require('square-php-sdk/autoload.php');
 require 'vendor/autoload.php';

--- a/connect-examples/v2/php_checkout/composer.json
+++ b/connect-examples/v2/php_checkout/composer.json
@@ -1,7 +1,6 @@
 {
   "require": {
-    "square/square": "*",
-    "vlucas/phpdotenv": "^3.3",
-    "php": "<8.1"
+    "square/square": "18.0.0.20220420",
+    "vlucas/phpdotenv": "^3.3"
   }
 }

--- a/connect-examples/v2/php_payment/README.md
+++ b/connect-examples/v2/php_payment/README.md
@@ -16,7 +16,7 @@ There are two sections in this README.
 
 ### Requirements
 
-* 7.1 <= PHP < 8.1
+* 7.1 <= PHP
 
 ### Install the PHP client library
 

--- a/connect-examples/v2/php_payment/composer.json
+++ b/connect-examples/v2/php_payment/composer.json
@@ -1,8 +1,7 @@
 {
   "require": {
-    "square/square": "*",
+    "square/square": "18.0.0.20220420",
     "vlucas/phpdotenv": "^3.3",
-    "ramsey/uuid": "*",
-    "php": "<8.1"
+    "ramsey/uuid": "*"
   }
 }

--- a/connect-examples/v2/php_payment/utils/location-info.php
+++ b/connect-examples/v2/php_payment/utils/location-info.php
@@ -1,12 +1,5 @@
 <?php
 
-// Make sure the sample app only runs with PHP < 8.1 for now.
-if (version_compare(phpversion(), '8.1.0', '>=')) {
-  echo 'Unsupported PHP version<br/>';
-  echo '<strong>This sample app is meant to be run with PHP version < 8.1. Change your PHP version and try again.</strong><br/>';
-  exit();
-}
-
 // Note this line needs to change if you don't use Composer:
 // require('square-php-sdk/autoload.php');
 require 'vendor/autoload.php';


### PR DESCRIPTION
Our newest release of the PHP SDK supports PHP version >= 8.1. I updated the PHP sample apps to not restrict the PHP version anymore.

Testing:
Manual testing.