### PR TITLE
fix subscription search query parameters

### DIFF
--- a/connect-examples/v2/node_subscription/routes/subscription.js
+++ b/connect-examples/v2/node_subscription/routes/subscription.js
@@ -54,8 +54,16 @@ router.get("/view/:locationId/:customerId/:subscriptionPlanId", async (req, res,
     const { result: { object } } = await catalogApi.retrieveCatalogObject(subscriptionPlanId);
     const subscriptionPlan = object.subscriptionPlanData;
     const { result: { subscriptions } } = await subscriptionsApi.searchSubscriptions({
-      locationIds: [locationId],
-      customerIds: [customerId]
+      query: {
+        filter: {
+          customerIds: [
+            customerId
+          ],
+          locationIds: [
+            locationId
+          ]
+        }
+      }
     });
 
     // find the first active subscription for the current plan


### PR DESCRIPTION
The current demo incorrectly shows the active subscriptions that a customer has subscribed to. 

For example, if Amelia subscribes to a Gym Membership plan, and then you view John Doe's subscription page and try to subscribe to the Gym Membership plan, you will see that is already marked as active when it should be inactive.

The problem occurs because the subscriptionsApi.searchSubscriptions() method has incorrect query parameters causing it to retrieve every subscription instead of the ones only owned by the customer.

Steps to reproduce error:
1. Click on Amelia
2. Click on Gym Membership Plan under Additional Plans
3. Click Subscribe
4. Go to John Doe
5. Click on Gym Membership Plan under Additional Plans
6. See that the Gym Membership Plan is already is active
