### PR TITLE
Fix oauth sample app obtainToken optional parameter

### DIFF
--- a/connect-examples/oauth/php/callback.php
+++ b/connect-examples/oauth/php/callback.php
@@ -25,15 +25,14 @@ function obtainOAuthToken($authorizationCode) {
     'userAgentDetail' => "sample_app_oauth_php" // Remove or replace this detail when building your own app
   ]);
   $oauthApi = $apiClient->getOAuthApi();
-
   // Initialize the request parameters for the obtainToken request.
   $body_grantType = 'authorization_code';
   $body = new ObtainTokenRequest(
     getenv('SQ_APPLICATION_ID'),
-    getenv('SQ_APPLICATION_SECRET'),
     $body_grantType
   );
   $body->setCode($authorizationCode);
+  $body->setClientSecret(getenv('SQ_APPLICATION_SECRET'));
 
   // Call obtainToken endpoint to get the OAuth tokens.
   try {


### PR DESCRIPTION
One of the recent releases changed the `clientSecret` to be an optional parameter for `ObtainToken`. Our SDK passed the `clientSecret` directly to the model constructor, but that parameter is now removed. The new behaviour will set the parameter outside the constructor.