### PR TITLE
Fix Payment SDK sample apps idempotency

### DIFF
--- a/connect-examples/v2/csharp_payment/Pages/ProcessPayment.cshtml.cs
+++ b/connect-examples/v2/csharp_payment/Pages/ProcessPayment.cshtml.cs
@@ -38,12 +38,8 @@ namespace sqRazorSample.Pages
     {
       var request = JObject.Parse(await new StreamReader(Request.Body).ReadToEndAsync());
       var token = (String)request["token"];
+      var idempotencyKey = (String)request["idempotencyKey"];
       var PaymentsApi = client.PaymentsApi;
-      // Every payment you process with the SDK must have a unique idempotency key.
-      // If you're unsure whether a particular payment succeeded, you can reattempt
-      // it with the same idempotency key without worrying about double charging
-      // the buyer.
-      string uuid = NewIdempotencyKey();
 
       // Get the currency for the location
       var retrieveLocationResponse = await client.LocationsApi.RetrieveLocationAsync(locationId: locationId);
@@ -62,7 +58,7 @@ namespace sqRazorSample.Pages
       // (https://developer.squareup.com/docs/payments-api/overview).
       var createPaymentRequest = new CreatePaymentRequest.Builder(
           sourceId: token,
-          idempotencyKey: uuid,
+          idempotencyKey: idempotencyKey,
           amountMoney: amount)
           .Build();
 
@@ -75,11 +71,6 @@ namespace sqRazorSample.Pages
       {
         return new JsonResult(new { errors = e.Errors });
       }
-    }
-
-    private static string NewIdempotencyKey()
-    {
-      return Guid.NewGuid().ToString();
     }
   }
 }

--- a/connect-examples/v2/csharp_payment/Pages/index.cshtml
+++ b/connect-examples/v2/csharp_payment/Pages/index.cshtml
@@ -11,6 +11,7 @@
         window.locationId = "@Model.LocationId";
         window.country = "@Model.Country";
         window.currency = "@Model.Currency";
+        window.idempotencyKey = "@Model.IdempotencyKey";
     </script>
     <!-- link to the local Web Payment SDK initialization -->
     <script type="text/javascript" src="~/js/sq-ach.js"></script>

--- a/connect-examples/v2/csharp_payment/Pages/index.cshtml.cs
+++ b/connect-examples/v2/csharp_payment/Pages/index.cshtml.cs
@@ -14,6 +14,7 @@ namespace sqRazorSample.Pages
         public string LocationId { get; set; }
         public string Currency { get; set; }
         public string Country { get; set; }
+        public string IdempotencyKey { get; set; }
 
         private SquareClient client;
 
@@ -24,6 +25,12 @@ namespace sqRazorSample.Pages
 
             ApplicationId = configuration["AppSettings:ApplicationId"];
             LocationId = configuration["AppSettings:LocationId"];
+
+            // Every payment you process with the SDK must have a unique idempotency key.
+            // If you're unsure whether a particular payment succeeded, you can reattempt
+            // it with the same idempotency key without worrying about double charging
+            // the buyer.
+            IdempotencyKey = NewIdempotencyKey();
 
             WebPaymentsSdkUrl = environment == Square.Environment.Sandbox ?
                 "https://sandbox.web.squarecdn.com/v1/square.js" : "https://web.squarecdn.com/v1/square.js" ;
@@ -39,6 +46,10 @@ namespace sqRazorSample.Pages
             var result = await client.LocationsApi.RetrieveLocationAsync(locationId: this.LocationId);
             this.Country = result.Location.Country;
             this.Currency = result.Location.Currency;
+        }
+
+        private static string NewIdempotencyKey() {
+          return Guid.NewGuid().ToString();
         }
     }
 }

--- a/connect-examples/v2/csharp_payment/wwwroot/js/sq-payment-flow.js
+++ b/connect-examples/v2/csharp_payment/wwwroot/js/sq-payment-flow.js
@@ -31,7 +31,8 @@ window.showError = function(message) {
 
 window.createPayment = async function(token) {
   const dataJsonString = JSON.stringify({
-    token
+    token,
+    idempotencyKey: window.idempotencyKey
   });
 
   try {

--- a/connect-examples/v2/java_payment/pom.xml
+++ b/connect-examples/v2/java_payment/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.squareup</groupId>
       <artifactId>square</artifactId>
-      <version>22.0.0.20220720</version>
+      <version>27.0.0.20221214</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>

--- a/connect-examples/v2/java_payment/pom.xml
+++ b/connect-examples/v2/java_payment/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.squareup</groupId>
       <artifactId>square</artifactId>
-      <version>27.0.0.20221214</version>
+      <version>22.0.0.20220720</version>
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
@@ -126,3 +126,4 @@
   </build>
 
 </project>
+

--- a/connect-examples/v2/java_payment/pom.xml
+++ b/connect-examples/v2/java_payment/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.7.5</version>
   </parent>
 
   <properties>

--- a/connect-examples/v2/java_payment/src/main/java/com/squareup/connectexamples/ecommerce/Main.java
+++ b/connect-examples/v2/java_payment/src/main/java/com/squareup/connectexamples/ecommerce/Main.java
@@ -65,12 +65,11 @@ public class Main {
     squareAppId = mustLoadEnvironmentVariable(SQUARE_APP_ID_ENV_VAR);
     squareLocationId = mustLoadEnvironmentVariable(SQUARE_LOCATION_ID_ENV_VAR);
 
-    System.out.println(squareEnvironment);
     squareClient = new SquareClient.Builder()
         .environment(Environment.fromString(squareEnvironment))
         .accessToken(mustLoadEnvironmentVariable(SQUARE_ACCESS_TOKEN_ENV_VAR))
+        .userAgentDetail("sample_app_java_payment") // Remove or replace this detail when building your own app
         .build();
-    System.out.println(squareClient);
   }
 
   public static void main(String[] args) throws Exception {
@@ -124,18 +123,18 @@ public class Main {
     CreatePaymentRequest createPaymentRequest = new CreatePaymentRequest.Builder(
         tokenObject.getToken(),
         tokenObject.getIdempotencyKey(),
-        bodyAmountMoney).locationId(squareLocationId)
+        bodyAmountMoney)
         .build();
 
-        PaymentsApi paymentsApi = squareClient.getPaymentsApi();
-        return paymentsApi.createPaymentAsync(createPaymentRequest).thenApply(result -> {
-          return new PaymentResult("SUCCESS", null);
-        }).exceptionally(exception -> {
-          ApiException e = (ApiException) exception.getCause();
-          System.out.println("Failed to make the request");
-          System.out.printf("Exception: %s%n", e.getMessage());
-          return new PaymentResult("FAILURE", e.getErrors());
-        }).join();
+    PaymentsApi paymentsApi = squareClient.getPaymentsApi();
+    return paymentsApi.createPaymentAsync(createPaymentRequest).thenApply(result -> {
+      return new PaymentResult("SUCCESS", null);
+    }).exceptionally(exception -> {
+      ApiException e = (ApiException) exception.getCause();
+      System.out.println("Failed to make the request");
+      System.out.printf("Exception: %s%n", e.getMessage());
+      return new PaymentResult("FAILURE", e.getErrors());
+    }).join();
   }
 
   /**

--- a/connect-examples/v2/java_payment/src/main/java/com/squareup/connectexamples/ecommerce/Main.java
+++ b/connect-examples/v2/java_payment/src/main/java/com/squareup/connectexamples/ecommerce/Main.java
@@ -121,31 +121,26 @@ public class Main {
         .currency(currency)
         .build();
 
-    System.out.println(tokenObject.getIdempotencyKey());
     CreatePaymentRequest createPaymentRequest = new CreatePaymentRequest.Builder(
         tokenObject.getToken(),
         tokenObject.getIdempotencyKey(),
         bodyAmountMoney).locationId(squareLocationId)
         .build();
 
-    PaymentsApi paymentsApi = squareClient.getPaymentsApi();
-    System.out.println(createPaymentRequest);
-    paymentsApi.createPaymentAsync(createPaymentRequest).thenAccept(result -> {
-      System.out.println("Success! aASDFASDFASDF");
-  }).exceptionally(exception -> {
-      System.out.println("Failed to make the request");
-      System.out.println(String.format("Exception: %s", exception.getMessage()));
-      return null;
-  });
-
-  SquareClient.shutdown();
-  return null;
+        PaymentsApi paymentsApi = squareClient.getPaymentsApi();
+        return paymentsApi.createPaymentAsync(createPaymentRequest).thenApply(result -> {
+          return new PaymentResult("SUCCESS", null);
+        }).exceptionally(exception -> {
+          ApiException e = (ApiException) exception.getCause();
+          System.out.println("Failed to make the request");
+          System.out.printf("Exception: %s%n", e.getMessage());
+          return new PaymentResult("FAILURE", e.getErrors());
+        }).join();
   }
 
   /**
    * Helper method that makes a retrieveLocation API call using the configured
-   * locationId and
-   * returns the future containing the response
+   * locationId and returns the future containing the response
    *
    * @param squareClient the API client
    * @return a future that holds the retrieveLocation response

--- a/connect-examples/v2/java_payment/src/main/java/com/squareup/connectexamples/ecommerce/TokenWrapper.java
+++ b/connect-examples/v2/java_payment/src/main/java/com/squareup/connectexamples/ecommerce/TokenWrapper.java
@@ -6,6 +6,7 @@ package com.squareup.connectexamples.ecommerce;
 public class TokenWrapper {
 
     private String token;
+    private String idempotencyKey;
 
     public String getToken() {
         return token;
@@ -13,5 +14,13 @@ public class TokenWrapper {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public String getIdempotencyKey() {
+      return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(String idempotencyKey) {
+      this.idempotencyKey = idempotencyKey;
     }
 }

--- a/connect-examples/v2/java_payment/src/main/resources/static/js/sq-payment-flow.js
+++ b/connect-examples/v2/java_payment/src/main/resources/static/js/sq-payment-flow.js
@@ -46,7 +46,6 @@ window.createPayment = async function(token) {
 
     const data = await response.json();
 
-    debugger;
     if (data.errors && data.errors.length > 0) {
       if (data.errors[0].detail) {
         window.showError(data.errors[0].detail);

--- a/connect-examples/v2/java_payment/src/main/resources/static/js/sq-payment-flow.js
+++ b/connect-examples/v2/java_payment/src/main/resources/static/js/sq-payment-flow.js
@@ -31,7 +31,8 @@ window.showError = function(message) {
 
 window.createPayment = async function(token) {
   const dataJsonString = JSON.stringify({
-    token
+    token,
+    idempotencyKey: window.idempotencyKey,
   });
 
   try {
@@ -45,6 +46,7 @@ window.createPayment = async function(token) {
 
     const data = await response.json();
 
+    debugger;
     if (data.errors && data.errors.length > 0) {
       if (data.errors[0].detail) {
         window.showError(data.errors[0].detail);

--- a/connect-examples/v2/java_payment/src/main/resources/templates/index.html
+++ b/connect-examples/v2/java_payment/src/main/resources/templates/index.html
@@ -12,6 +12,7 @@
     window.locationId = '[[${locationId}]]';
     window.currency = '[[${currency}]]';
     window.country = '[[${country}]]';
+    window.idempotencyKey = '[[${idempotencyKey}]]';
   </script>
   <!--
     These styles can live in a separate .css file. They're just here to keep this

--- a/connect-examples/v2/node_payment/package-lock.json
+++ b/connect-examples/v2/node_payment/package-lock.json
@@ -792,11 +792,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1184,17 +1179,6 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -1753,14 +1737,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2237,11 +2213,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",

--- a/connect-examples/v2/node_payment/public/js/sq-payment-flow.js
+++ b/connect-examples/v2/node_payment/public/js/sq-payment-flow.js
@@ -31,7 +31,8 @@ window.showError = function(message) {
 
 window.createPayment = async function(token) {
   const dataJsonString = JSON.stringify({
-    token
+    token,
+    idempotencyKey: window.idempotencyKey
   });
 
   try {

--- a/connect-examples/v2/node_payment/routes/index.js
+++ b/connect-examples/v2/node_payment/routes/index.js
@@ -11,6 +11,7 @@ router.get('/', async function (req, res) {
   const locationResponse = await locationsApi.retrieveLocation(process.env.SQUARE_LOCATION_ID);
   const currency = locationResponse.result.location.currency;
   const country = locationResponse.result.location.country;
+  const idempotencyKey = uuidv4();
 
   // Set the app and location ids for Payment Web SDK to use
   res.render('index', {
@@ -20,14 +21,14 @@ router.get('/', async function (req, res) {
     squareLocationId: process.env.SQUARE_LOCATION_ID,
     squareAccountCountry: country,
     squareAccountCurrency: currency,
+    idempotencyKey
   });
 });
 
 router.post('/process-payment', async (req, res) => {
   const token = req.body.token;
-
-  // length of idempotency_key should be less than 45
-  const idempotencyKey = uuidv4();
+  const idempotencyKey = req.body.idempotencyKey;
+  console.log(idempotencyKey);
 
   // get the currency for the location
   const locationResponse = await locationsApi.retrieveLocation(process.env.SQUARE_LOCATION_ID);

--- a/connect-examples/v2/node_payment/routes/index.js
+++ b/connect-examples/v2/node_payment/routes/index.js
@@ -28,7 +28,6 @@ router.get('/', async function (req, res) {
 router.post('/process-payment', async (req, res) => {
   const token = req.body.token;
   const idempotencyKey = req.body.idempotencyKey;
-  console.log(idempotencyKey);
 
   // get the currency for the location
   const locationResponse = await locationsApi.retrieveLocation(process.env.SQUARE_LOCATION_ID);

--- a/connect-examples/v2/node_payment/views/index.pug
+++ b/connect-examples/v2/node_payment/views/index.pug
@@ -9,6 +9,7 @@ block content
     window.locationId="#{squareLocationId}";
     window.currency="#{squareAccountCurrency}";
     window.country="#{squareAccountCountry}";
+    window.idempotencyKey="#{idempotencyKey}"
 
   form(class="payment-form" id="fast-checkout")
     div(class="wrapper")

--- a/connect-examples/v2/php_payment/README.md
+++ b/connect-examples/v2/php_payment/README.md
@@ -17,7 +17,7 @@ There are two sections in this README.
 
 ### Requirements
 
-- 8.0 <= PHP
+- 8.0 <= PHP < 8.2
 
 ### Install the PHP client library
 

--- a/connect-examples/v2/php_payment/index.php
+++ b/connect-examples/v2/php_payment/index.php
@@ -3,6 +3,7 @@ require 'vendor/autoload.php';
 include 'utils/location-info.php';
 
 use Square\Environment;
+use Ramsey\Uuid\Uuid;
 // dotenv is used to read from the '.env' file created for credentials
 $dotenv = Dotenv\Dotenv::create(__DIR__);
 $dotenv->load();
@@ -35,6 +36,10 @@ $web_payment_sdk_url = $_ENV["ENVIRONMENT"] === Environment::PRODUCTION ? "https
     window.country =
       "<?php
         echo $location_info->getCountry();
+        ?>";
+    window.idempotencyKey =
+      "<?php
+        echo Uuid::uuid4();
         ?>";
   </script>
   <link rel="stylesheet" type="text/css" href="public/stylesheets/style.css">

--- a/connect-examples/v2/php_payment/process-payment.php
+++ b/connect-examples/v2/php_payment/process-payment.php
@@ -26,6 +26,7 @@ if ($_SERVER['REQUEST_METHOD'] != 'POST') {
 $json = file_get_contents('php://input');
 $data = json_decode($json);
 $token = $data->token;
+$idempotencyKey = $data->idempotencyKey;
 
 $square_client = new SquareClient([
   'accessToken' => getenv('SQUARE_ACCESS_TOKEN'),
@@ -47,11 +48,11 @@ $money->setAmount(100);
 $money->setCurrency($location_info->getCurrency());
 
 try {
-// Every payment you process with the SDK must have a unique idempotency key.
-// If you're unsure whether a particular payment succeeded, you can reattempt
-// it with the same idempotency key without worrying about double charging
-// the buyer.
-  $create_payment_request = new CreatePaymentRequest($token, Uuid::uuid4(), $money);
+  // Every payment you process with the SDK must have a unique idempotency key.
+  // If you're unsure whether a particular payment succeeded, you can reattempt
+  // it with the same idempotency key without worrying about double charging
+  // the buyer.
+  $create_payment_request = new CreatePaymentRequest($token, $idempotencyKey, $money);
   $create_payment_request->setLocationId($location_info->getId());
 
   $response = $payments_api->createPayment($create_payment_request);

--- a/connect-examples/v2/php_payment/public/js/sq-payment-flow.js
+++ b/connect-examples/v2/php_payment/public/js/sq-payment-flow.js
@@ -31,7 +31,8 @@ window.showError = function(message) {
 
 window.createPayment = async function(token) {
   const dataJsonString = JSON.stringify({
-    token
+    token,
+    idempotencyKey: window.idempotencyKey
   });
 
   try {

--- a/connect-examples/v2/python_payment/README.md
+++ b/connect-examples/v2/python_payment/README.md
@@ -22,7 +22,7 @@ Make sure you have Python >= 3.4
 
 2. Run the following command to install `squareup` package and other dependencies:
 
-   `pip install -r requirements.txt`
+   `pip install -r requirements.txt` or `pip3 install -r requirements.txt`
 
 ### Provide required credentials
 

--- a/connect-examples/v2/python_payment/main.py
+++ b/connect-examples/v2/python_payment/main.py
@@ -35,7 +35,6 @@ location = client.locations.retrieve_location(location_id=LOCATION_ID).body["loc
 ACCOUNT_CURRENCY = location["currency"]
 ACCOUNT_COUNTRY = location["country"]
 
-
 def generate_index_html():
     html_content = (
         """<!DOCTYPE html>
@@ -63,6 +62,9 @@ def generate_index_html():
         + """';
             window.country = '"""
         + ACCOUNT_COUNTRY
+        + """';
+            window.idempotencyKey = '"""
+        + str(uuid.uuid4())
         + """';
         </script>
 
@@ -121,6 +123,7 @@ def generate_index_html():
 
 class Payment(BaseModel):
     token: str
+    idempotencyKey: str
 
 
 app = FastAPI()
@@ -139,7 +142,7 @@ def create_payment(payment: Payment):
     create_payment_response = client.payments.create_payment(
         body={
             "source_id": payment.token,
-            "idempotency_key": str(uuid.uuid4()),
+            "idempotency_key": payment.idempotencyKey,
             "amount_money": {
                 "amount": 100,  # $1.00 charge
                 "currency": ACCOUNT_CURRENCY,

--- a/connect-examples/v2/python_payment/static/js/sq-payment-flow.js
+++ b/connect-examples/v2/python_payment/static/js/sq-payment-flow.js
@@ -31,7 +31,8 @@ window.showError = function(message) {
 
 window.createPayment = async function(token) {
   const dataJsonString = JSON.stringify({
-    token
+    token,
+    idempotencyKey: window.idempotencyKey
   });
 
   try {

--- a/connect-examples/v2/rails_payment/app/assets/javascripts/sq-payment-flow.js
+++ b/connect-examples/v2/rails_payment/app/assets/javascripts/sq-payment-flow.js
@@ -31,7 +31,8 @@ window.showError = function(message) {
 
 window.createPayment = async function(token) {
   const dataJsonString = JSON.stringify({
-    token
+    token,
+    idempotencyKey: window.idempotencyKey
   });
 
   try {
@@ -45,6 +46,7 @@ window.createPayment = async function(token) {
 
     const data = await response.json();
 
+    debugger;
     if (data.errors && data.errors.length > 0) {
       if (data.errors[0].detail) {
         window.showError(data.errors[0].detail);

--- a/connect-examples/v2/rails_payment/app/assets/javascripts/sq-payment-flow.js
+++ b/connect-examples/v2/rails_payment/app/assets/javascripts/sq-payment-flow.js
@@ -46,7 +46,6 @@ window.createPayment = async function(token) {
 
     const data = await response.json();
 
-    debugger;
     if (data.errors && data.errors.length > 0) {
       if (data.errors[0].detail) {
         window.showError(data.errors[0].detail);

--- a/connect-examples/v2/rails_payment/app/controllers/payments_controller.rb
+++ b/connect-examples/v2/rails_payment/app/controllers/payments_controller.rb
@@ -20,10 +20,14 @@ class PaymentsController < ApplicationController
         :amount => 100,
         :currency => currency
       },
-      :idempotency_key => SecureRandom.uuid
+      :idempotency_key => params[:idempotencyKey]
     }
 
     resp = square_api_client.payments.create_payment(body: request_body)
-    render json: resp.data.payment
+    if resp.success?
+      render json: resp.data.payment
+    elsif resp.error?
+      render json: resp
+    end
   end
 end

--- a/connect-examples/v2/rails_payment/app/controllers/welcome_controller.rb
+++ b/connect-examples/v2/rails_payment/app/controllers/welcome_controller.rb
@@ -9,6 +9,7 @@ class WelcomeController < ApplicationController
 
     @country = location[:country]
     @currency = location[:currency]
+    @idempotencyKey = SecureRandom.uuid
 
     render layout: 'index'
   end

--- a/connect-examples/v2/rails_payment/app/views/welcome/index.html.erb
+++ b/connect-examples/v2/rails_payment/app/views/welcome/index.html.erb
@@ -1,6 +1,7 @@
 <script type="text/javascript">
   window.country = "<%= @country %>"
   window.currency = "<%= @currency %>"
+  window.idempotencyKey = "<%= @idempotencyKey %>"
 </script>
 
 <form class="payment-form" id="fast-checkout">


### PR DESCRIPTION
Previously, we would generate a new idempotency key for each payment. This is bad practice, since the reason we use idempotency key in the first place is to prevent issues like multiple clicks or accidentally submitting multiple payment requests. I fixed the sample apps so that we generate the idempotency key on page load. 

**Previous behaviour:** loading the app and paying multiple times would "charge" the user multiple times since different idempotency keys are used for every request.

**New behaviour**: loading the app and paying multiple times would still generate multiple requests, but with the same idempotency key. Only the first payment will be successful.

Additionally, I fixed an issue with the Java payment app which wasn't working properly, and added some additional error handling to the rails payment sample.