### PR TITLE
Update invoice sample app

### DIFF
--- a/connect-examples/v2/node_invoices/bin/script/seed-data.js
+++ b/connect-examples/v2/node_invoices/bin/script/seed-data.js
@@ -20,17 +20,18 @@ const { Client, Environment } = require("square");
 const readline = require("readline");
 const { v4: uuidv4 } = require("uuid");
 const { program } = require("commander");
-require('dotenv').config()
+require("dotenv").config();
 
 // We don't recommend to run this script in production environment
 const config = {
   environment: Environment.Sandbox,
   accessToken: process.env.SQUARE_ACCESS_TOKEN
 
-}
+};
 
 // Configure customer API instance
 const {
+  cardsApi,
   customersApi
 } = new Client(config);
 
@@ -49,8 +50,12 @@ async function addCustomers() {
       emailAddress: "nakamura710@square-example.com" // it is a fake email
     });
 
-    await customersApi.createCustomerCard(customer.id, {
-      cardNonce: "cnon:card-nonce-ok"
+    await cardsApi.createCard({
+      idempotencyKey: uuidv4(),
+      sourceId: "cnon:card-nonce-ok",
+      card: {
+        customerId: customer.id
+      }
     });
 
     // create second customer with no card on file

--- a/connect-examples/v2/node_invoices/package-lock.json
+++ b/connect-examples/v2/node_invoices/package-lock.json
@@ -20,7 +20,8 @@
         "pug": "^3.0.0",
         "request": "^2.88.0",
         "serve-favicon": "^2.5.0",
-        "square": "^22.0.0",
+        "square": "^28.0.0",
+        "tslib": "^2.6.0",
         "uuid": "^8.3.0"
       },
       "devDependencies": {
@@ -28,25 +29,35 @@
         "nodemon": "^2.0.4"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": ">=14.15.0"
       }
     },
-    "node_modules/@apimatic/convert-to-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.0.2.tgz",
-      "integrity": "sha512-1DRg17ItExfMYsXwjt6WIjJSCgV5RGg3fHPLgYD44/YmiU+7suWj7YfPKKUqmNcnJ/AvMh4lG1+tHrfOT01zXw==",
-      "engines": {
-        "node": ">=10.4.0"
-      }
-    },
-    "node_modules/@apimatic/core": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.7.9.tgz",
-      "integrity": "sha512-zoOXyaZxaZdu9OwwArD70a+1WQQzPenocBjr1tkhOeFv73lXjihxHOOt6dBplQUU/FL279FnKCE/QP4vBipRGw==",
+    "node_modules/@apimatic/authentication-adapters": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/authentication-adapters/-/authentication-adapters-0.5.1.tgz",
+      "integrity": "sha512-UHGTQXRIBpyGVM/3JSmPceIOpDHIBnz044b2tXlDP4Sh3lMeyoMcToXT72fWg6DI9N3EG4U141o7oIu8dKe/Eg==",
       "dependencies": {
-        "@apimatic/convert-to-stream": "0.0.2",
+        "@apimatic/core-interfaces": "^0.2.0",
+        "@apimatic/http-headers": "^0.3.0",
+        "@apimatic/http-query": "^0.3.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/axios-client-adapter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/axios-client-adapter/-/axios-client-adapter-0.2.2.tgz",
+      "integrity": "sha512-cbMd/CiIUmbtYpHjQgptptkeeWWko8MtuOI5rJfqxL/ElYI0ABSytdO5fuT4Q+hXQHQrkPRgL2z9yUMRoFEARg==",
+      "dependencies": {
+        "@apimatic/convert-to-stream": "^0.1.0",
+        "@apimatic/core-interfaces": "^0.2.0",
+        "@apimatic/file-wrapper": "^0.3.0",
+        "@apimatic/http-headers": "^0.3.0",
+        "@apimatic/http-query": "^0.3.0",
         "@apimatic/json-bigint": "^1.2.0",
-        "@apimatic/schema": "^0.6.0",
+        "@apimatic/schema": "^0.7.0",
         "axios": "^0.21.1",
         "detect-browser": "^5.3.0",
         "detect-node": "^2.0.4",
@@ -55,6 +66,72 @@
         "tiny-warning": "^1.0.3",
         "tslib": "^2.1.0"
       },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/axios-client-adapter/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@apimatic/convert-to-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.1.0.tgz",
+      "integrity": "sha512-yVwPBnUhFD0X+veZ9KaVXBv/9svSB41GOp51Y5W+tMM316fXFQRC8jlc3XONRabQ2QWfwCz7iLtdABL41VXRcA==",
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/core": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.10.2.tgz",
+      "integrity": "sha512-KPoeHmFnaMJHU1itJV0PwiQnMauI9WI2tPnCyrpOucyHupirH8JqtAKcYD5AVRoL9hKSCiFwTKd9pX9glVJgKQ==",
+      "dependencies": {
+        "@apimatic/convert-to-stream": "^0.0.2",
+        "@apimatic/core-interfaces": "^0.2.0",
+        "@apimatic/file-wrapper": "^0.3.0",
+        "@apimatic/http-headers": "^0.3.0",
+        "@apimatic/http-query": "^0.3.0",
+        "@apimatic/json-bigint": "^1.2.0",
+        "@apimatic/schema": "^0.7.0",
+        "axios": "^0.21.1",
+        "detect-browser": "^5.3.0",
+        "detect-node": "^2.0.4",
+        "form-data": "^3.0.0",
+        "json-ptr": "^3.1.0",
+        "lodash.flatmap": "^4.5.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/core-interfaces": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/core-interfaces/-/core-interfaces-0.2.2.tgz",
+      "integrity": "sha512-SFy74jNUfYFk47UyO4gZOB5IT+xxn8m2sMo99461d7i6OTIeYxD5uI2X2LNB97CqhKu+xCku9FgBMGgKDI9wNQ==",
+      "dependencies": {
+        "@apimatic/file-wrapper": "^0.3.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/core/node_modules/@apimatic/convert-to-stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.0.2.tgz",
+      "integrity": "sha512-1DRg17ItExfMYsXwjt6WIjJSCgV5RGg3fHPLgYD44/YmiU+7suWj7YfPKKUqmNcnJ/AvMh4lG1+tHrfOT01zXw==",
       "engines": {
         "node": ">=10.4.0"
       }
@@ -72,10 +149,39 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@apimatic/core/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    "node_modules/@apimatic/file-wrapper": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/file-wrapper/-/file-wrapper-0.3.1.tgz",
+      "integrity": "sha512-RUJe0fNO/b7vgH0jFjMgyRqBILNQ4kYZcZz8cxd3DODjKBT0R+jS6IU1KIDOTj2lJFdvPmIuPUOJbilKI2eAmA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/http-headers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-headers/-/http-headers-0.3.1.tgz",
+      "integrity": "sha512-q5cmRHbSnweet2FFW4NSTZaVPdmVZLJJTUFdMs3dJON+tw2WcH2bNprORi26DrYBE0Dz/4u1Fip5uqRvBYNULA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@apimatic/http-query": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-query/-/http-query-0.3.1.tgz",
+      "integrity": "sha512-YC/dFTX35Q3XWuVbTgEFsQVmpVJlmSrfhI7TBuiUTSlex0uPi3cBQejnLPq0+thpCbGifaL/J+bRbngBO3Kt3Q==",
+      "dependencies": {
+        "@apimatic/file-wrapper": "^0.3.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=14.15.0 || >=16.0.0"
+      }
     },
     "node_modules/@apimatic/json-bigint": {
       "version": "1.2.0",
@@ -83,20 +189,15 @@
       "integrity": "sha512-+bmVzYMdZu0Ya5L+my4FXFUih54OvQA/qlZsFOYdOoostyUuB27UDrVWQs/WVCmS0ADdo5vTU0eeTrrBkHoySw=="
     },
     "node_modules/@apimatic/schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.6.0.tgz",
-      "integrity": "sha512-JgG32LQRLphHRWsn64vIt7wD2m+JH46swM6ZrY7g1rdiGiKV5m+A+TBrJKoUUQRmS14azMgePNZY30NauWqzLg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.7.2.tgz",
+      "integrity": "sha512-Rta8SLkWfx3LIc4eaJZcQ2ygZydrY/6rB3KA0raJg1kc9mo4P5qCq8U13ngmW13cpaZ0drZf1MeDaDfjfKo+zw==",
       "dependencies": {
         "tslib": "^2.1.0"
       },
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/@apimatic/schema/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -448,7 +549,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
+      "extraneous": true,
       "engines": {
         "node": ">=10"
       },
@@ -1806,6 +1907,11 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
+    "node_modules/json-ptr": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-ptr/-/json-ptr-3.1.1.tgz",
+      "integrity": "sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg=="
+    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -2002,11 +2108,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -2612,6 +2713,12 @@
         "npm": ">=2.0.0"
       }
     },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2821,17 +2928,19 @@
       "dev": true
     },
     "node_modules/square": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/square/-/square-22.0.0.tgz",
-      "integrity": "sha512-3KZkwml3vIM/fL06bPOTeAyFj1Pn1e1Ps2P/nGFI9tcMMfu+0mxqx4kOLYVkYE2NaCHs/V4pPD/JkO4s9ravqA==",
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/square/-/square-28.0.1.tgz",
+      "integrity": "sha512-xMOgk9obO7QEfPNeoyIrQZ4ffFOK+rpwWOceafdN+xATZrlebhFk7Y3yIsJuF1F6tvBTFzqzjOHgfv0Ihi1aBQ==",
       "dependencies": {
-        "@apimatic/core": "^0.7.7",
+        "@apimatic/authentication-adapters": "^0.5.0",
+        "@apimatic/axios-client-adapter": "^0.2.0",
+        "@apimatic/core": "^0.10.0",
         "@apimatic/json-bigint": "^1.2.0",
-        "@apimatic/schema": "^0.6.0",
+        "@apimatic/schema": "^0.7.0",
         "@types/node": "^14.14.30"
       },
       "engines": {
-        "node": ">=10.4.0"
+        "node": ">=14.17.0"
       }
     },
     "node_modules/sshpk": {
@@ -3079,10 +3188,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -3241,77 +3349,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -3332,19 +3369,29 @@
     }
   },
   "dependencies": {
-    "@apimatic/convert-to-stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.0.2.tgz",
-      "integrity": "sha512-1DRg17ItExfMYsXwjt6WIjJSCgV5RGg3fHPLgYD44/YmiU+7suWj7YfPKKUqmNcnJ/AvMh4lG1+tHrfOT01zXw=="
-    },
-    "@apimatic/core": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.7.9.tgz",
-      "integrity": "sha512-zoOXyaZxaZdu9OwwArD70a+1WQQzPenocBjr1tkhOeFv73lXjihxHOOt6dBplQUU/FL279FnKCE/QP4vBipRGw==",
+    "@apimatic/authentication-adapters": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/authentication-adapters/-/authentication-adapters-0.5.1.tgz",
+      "integrity": "sha512-UHGTQXRIBpyGVM/3JSmPceIOpDHIBnz044b2tXlDP4Sh3lMeyoMcToXT72fWg6DI9N3EG4U141o7oIu8dKe/Eg==",
       "requires": {
-        "@apimatic/convert-to-stream": "0.0.2",
+        "@apimatic/core-interfaces": "^0.2.0",
+        "@apimatic/http-headers": "^0.3.0",
+        "@apimatic/http-query": "^0.3.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@apimatic/axios-client-adapter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/axios-client-adapter/-/axios-client-adapter-0.2.2.tgz",
+      "integrity": "sha512-cbMd/CiIUmbtYpHjQgptptkeeWWko8MtuOI5rJfqxL/ElYI0ABSytdO5fuT4Q+hXQHQrkPRgL2z9yUMRoFEARg==",
+      "requires": {
+        "@apimatic/convert-to-stream": "^0.1.0",
+        "@apimatic/core-interfaces": "^0.2.0",
+        "@apimatic/file-wrapper": "^0.3.0",
+        "@apimatic/http-headers": "^0.3.0",
+        "@apimatic/http-query": "^0.3.0",
         "@apimatic/json-bigint": "^1.2.0",
-        "@apimatic/schema": "^0.6.0",
+        "@apimatic/schema": "^0.7.0",
         "axios": "^0.21.1",
         "detect-browser": "^5.3.0",
         "detect-node": "^2.0.4",
@@ -3363,12 +3410,85 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
-        },
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
+      }
+    },
+    "@apimatic/convert-to-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.1.0.tgz",
+      "integrity": "sha512-yVwPBnUhFD0X+veZ9KaVXBv/9svSB41GOp51Y5W+tMM316fXFQRC8jlc3XONRabQ2QWfwCz7iLtdABL41VXRcA=="
+    },
+    "@apimatic/core": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.10.2.tgz",
+      "integrity": "sha512-KPoeHmFnaMJHU1itJV0PwiQnMauI9WI2tPnCyrpOucyHupirH8JqtAKcYD5AVRoL9hKSCiFwTKd9pX9glVJgKQ==",
+      "requires": {
+        "@apimatic/convert-to-stream": "^0.0.2",
+        "@apimatic/core-interfaces": "^0.2.0",
+        "@apimatic/file-wrapper": "^0.3.0",
+        "@apimatic/http-headers": "^0.3.0",
+        "@apimatic/http-query": "^0.3.0",
+        "@apimatic/json-bigint": "^1.2.0",
+        "@apimatic/schema": "^0.7.0",
+        "axios": "^0.21.1",
+        "detect-browser": "^5.3.0",
+        "detect-node": "^2.0.4",
+        "form-data": "^3.0.0",
+        "json-ptr": "^3.1.0",
+        "lodash.flatmap": "^4.5.0",
+        "tiny-warning": "^1.0.3",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "@apimatic/convert-to-stream": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.0.2.tgz",
+          "integrity": "sha512-1DRg17ItExfMYsXwjt6WIjJSCgV5RGg3fHPLgYD44/YmiU+7suWj7YfPKKUqmNcnJ/AvMh4lG1+tHrfOT01zXw=="
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@apimatic/core-interfaces": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/core-interfaces/-/core-interfaces-0.2.2.tgz",
+      "integrity": "sha512-SFy74jNUfYFk47UyO4gZOB5IT+xxn8m2sMo99461d7i6OTIeYxD5uI2X2LNB97CqhKu+xCku9FgBMGgKDI9wNQ==",
+      "requires": {
+        "@apimatic/file-wrapper": "^0.3.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "@apimatic/file-wrapper": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/file-wrapper/-/file-wrapper-0.3.1.tgz",
+      "integrity": "sha512-RUJe0fNO/b7vgH0jFjMgyRqBILNQ4kYZcZz8cxd3DODjKBT0R+jS6IU1KIDOTj2lJFdvPmIuPUOJbilKI2eAmA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@apimatic/http-headers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-headers/-/http-headers-0.3.1.tgz",
+      "integrity": "sha512-q5cmRHbSnweet2FFW4NSTZaVPdmVZLJJTUFdMs3dJON+tw2WcH2bNprORi26DrYBE0Dz/4u1Fip5uqRvBYNULA==",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "@apimatic/http-query": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-query/-/http-query-0.3.1.tgz",
+      "integrity": "sha512-YC/dFTX35Q3XWuVbTgEFsQVmpVJlmSrfhI7TBuiUTSlex0uPi3cBQejnLPq0+thpCbGifaL/J+bRbngBO3Kt3Q==",
+      "requires": {
+        "@apimatic/file-wrapper": "^0.3.0",
+        "tslib": "^2.1.0"
       }
     },
     "@apimatic/json-bigint": {
@@ -3377,18 +3497,11 @@
       "integrity": "sha512-+bmVzYMdZu0Ya5L+my4FXFUih54OvQA/qlZsFOYdOoostyUuB27UDrVWQs/WVCmS0ADdo5vTU0eeTrrBkHoySw=="
     },
     "@apimatic/schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.6.0.tgz",
-      "integrity": "sha512-JgG32LQRLphHRWsn64vIt7wD2m+JH46swM6ZrY7g1rdiGiKV5m+A+TBrJKoUUQRmS14azMgePNZY30NauWqzLg==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.7.2.tgz",
+      "integrity": "sha512-Rta8SLkWfx3LIc4eaJZcQ2ygZydrY/6rB3KA0raJg1kc9mo4P5qCq8U13ngmW13cpaZ0drZf1MeDaDfjfKo+zw==",
       "requires": {
         "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-        }
       }
     },
     "@babel/code-frame": {
@@ -4697,6 +4810,11 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
+    "json-ptr": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-ptr/-/json-ptr-3.1.1.tgz",
+      "integrity": "sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg=="
+    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -5331,6 +5449,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -5505,13 +5631,15 @@
       "dev": true
     },
     "square": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/square/-/square-22.0.0.tgz",
-      "integrity": "sha512-3KZkwml3vIM/fL06bPOTeAyFj1Pn1e1Ps2P/nGFI9tcMMfu+0mxqx4kOLYVkYE2NaCHs/V4pPD/JkO4s9ravqA==",
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/square/-/square-28.0.1.tgz",
+      "integrity": "sha512-xMOgk9obO7QEfPNeoyIrQZ4ffFOK+rpwWOceafdN+xATZrlebhFk7Y3yIsJuF1F6tvBTFzqzjOHgfv0Ihi1aBQ==",
       "requires": {
-        "@apimatic/core": "^0.7.7",
+        "@apimatic/authentication-adapters": "^0.5.0",
+        "@apimatic/axios-client-adapter": "^0.2.0",
+        "@apimatic/core": "^0.10.0",
         "@apimatic/json-bigint": "^1.2.0",
-        "@apimatic/schema": "^0.6.0",
+        "@apimatic/schema": "^0.7.0",
         "@types/node": "^14.14.30"
       }
     },
@@ -5699,10 +5827,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5821,58 +5948,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/connect-examples/v2/node_invoices/package.json
+++ b/connect-examples/v2/node_invoices/package.json
@@ -22,7 +22,8 @@
     "pug": "^3.0.0",
     "request": "^2.88.0",
     "serve-favicon": "^2.5.0",
-    "square": "^22.0.0",
+    "square": "^28.0.0",
+    "tslib": "^2.6.0",
     "uuid": "^8.3.0"
   },
   "devDependencies": {
@@ -30,6 +31,6 @@
     "nodemon": "^2.0.4"
   },
   "engines": {
-    "node": ">=10.0"
+    "node": ">=14.15.0"
   }
 }

--- a/connect-examples/v2/node_invoices/util/square-client.js
+++ b/connect-examples/v2/node_invoices/util/square-client.js
@@ -37,6 +37,7 @@ const defaultClient = new Client(clientConfig);
 // Instances of Api that are used
 // You can add additional APIs here if you so choose
 const {
+  cardsApi,
   customersApi,
   locationsApi,
   ordersApi,
@@ -45,6 +46,7 @@ const {
 
 // Makes API instances and util functions importable
 module.exports = {
+  cardsApi,
   customersApi,
   locationsApi,
   ordersApi,


### PR DESCRIPTION
This PR updates the invoice sample app and fixes a few issues:
1. Minimum node version is now V14.15.0.
2. The sample app is now using the latest SDK version.
3. Replace deprecated methods such as `createCustomerCard` and replace them with up-to-date ones (`createCard`).
4. Since cards are not part of the customer object anymore, use `ListCards` with customer ID to fetch cards associated with a certain customer.
5. Add error handling/retry for cases where the invoice to create contains unsupported/premium features according to this migration guide: https://developer.squareup.com/docs/invoices-api/overview#migration-notes
6. Fix README.